### PR TITLE
Replaced sublimegit with gitsavvy

### DIFF
--- a/layers/git/README.md
+++ b/layers/git/README.md
@@ -1,15 +1,24 @@
 # Git Layer
 
-This layer adds basic git support and is powered by [SublimeGit](https://sublimegit.net/) (for the moment).
+This layer adds basic git support and is powered by [GitSavvy](https://github.com/divmain/GitSavvy/).
 
 ## Requirements
 
-- a valid [SublimeGit](https://sublimegit.net/) license (they offer a free trial)
 - Git on your system
 
 ## Configuration
 
-None yet. Check out SublimeGit specific configurations
+None yet. Check out [GitSavvy](https://github.com/divmain/GitSavvy/blob/master/GitSavvy.sublime-settings) for things you can change. 
+
+To use github integration, add the following under your `package_settings` inside `.sublimious`:
+
+```
+"GitSavvy": {
+    "api_tokens": {
+        "github.com": "API TOKEN HERE"
+    }
+}
+```
 
 ## Usage
 
@@ -22,6 +31,7 @@ None yet. Check out SublimeGit specific configurations
 - `<spc> g f`: Git fetch
 - `<spc> g l`: Git log
 - `<spc> g a`: Git amend
+- `<spc> g b`: Git blame
 
 ### Navigation
 

--- a/layers/git/layer.py
+++ b/layers/git/layer.py
@@ -3,27 +3,27 @@ class Layer():
 
     required_packages = [
         "GitGutter",
-        "SublimeGit",
+        "GitSavvy",
     ]
 
     sublimious_keymap = [
         # ----- Git
         {"keys": ["g"], "category": "git"},
-        {"keys": ["g", "s"], "command": "git_status", "description": "status", "args": {}},
-        {"keys": ["g", "p"], "command": "git_push", "description": "push", "args": {}},
-        {"keys": ["g", "n"], "command": "git_checkout_new_branch", "description": "new branch", "args": {}},
-        {"keys": ["g", "c"], "command": "git_checkout_branch", "description": "checkout", "args": {}},
-        {"keys": ["g", "l"], "command": "git_log", "description": "log", "args": {}},
-        {"keys": ["g", "f"], "command": "git_fetch", "description": "fetch", "args": {}},
-        {"keys": ["g", "a"], "command": "git_commit_amend", "description": "amend", "args": {}},
+        {"keys": ["g", "s"], "command": "gs_show_status", "description": "status", "args": {}},
+        {"keys": ["g", "p"], "command": "gs_push", "description": "push", "args": {}},
+        {"keys": ["g", "n"], "command": "gs_checkout_new_branch", "description": "new branch", "args": {}},
+        {"keys": ["g", "c"], "command": "gs_checkout_branch", "description": "checkout", "args": {}},
+        {"keys": ["g", "l"], "command": "gs_log", "description": "log", "args": {}},
+        {"keys": ["g", "f"], "command": "gs_fetch", "description": "fetch", "args": {}},
+        {"keys": ["g", "a"], "command": "gs_commit", "description": "amend", "args": {"amend": True}},
+        {"keys": ["g", "d"], "command": "gs_diff", "description": "diff", "args": {}},
     ]
 
     sublime_keymap = [
-        {"keys": ["j"], "command": "git_status_move", "args": {"goto": "item:next"}, "context": [{"key": "selector", "operator": "equal", "operand": "text.git-status"}]},
-        {"keys": ["k"], "command": "git_status_move", "args": {"goto": "item:prev"}, "context": [{"key": "selector", "operator": "equal", "operand": "text.git-status"}]},
-        {"keys": ["q"], "command": "close", "context": [{"key": "selector", "operator": "equal", "operand": "text.git-status"}]},
-        {"keys": ["q"], "command": "close", "context": [{"key": "selector", "operator": "equal", "operand": "source.git-diff"}]},
-        {"keys": ["q"], "command": "close", "context": [{"key": "selector", "operator": "equal", "operand": "source.git-status"}]},
+        {"keys": ["j"], "command": "move", "args": {"by": "lines", "forward": True}, "context": [{"key": "setting.git_savvy.status_view", "operator": "equal", "operand": True}]},
+        {"keys": ["k"], "command": "move", "args": {"by": "lines", "forward": False}, "context": [{"key": "setting.git_savvy.status_view", "operator": "equal", "operand": True}]},
+        {"keys": ["q"], "command": "close", "args": {}, "context": [{"key": "setting.git_savvy.status_view", "operator": "equal", "operand": True}]},
+        {"keys": ["q"], "command": "close", "args": {}, "context": [{"key": "setting.git_savvy.diff_view", "operator": "equal", "operand": True}]},
     ]
 
     syntax_definitions = {}

--- a/layers/git/settings.py
+++ b/layers/git/settings.py
@@ -1,8 +1,8 @@
 {
     "package_settings": {
-        "SublimeGit": {
-            "git_commit_pedantic": True,
-            "git_commit_verbose": True
+        "GitSavvy": {
+            "show_commit_diff": True,
+            "show_git_flow_commands": True
         }
     }
 }


### PR DESCRIPTION
Sparked by https://github.com/dvcrn/sublimious/issues/3. 

Although SublimeGit is free now, GitSavvy seems to have a lot more features and a stable community around it. 
