### PR TITLE
Support for package control and .sublimious reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ __Be warned__! Sublimious is a complete configuration system and will nuke your 
 
 ### Keybindings
 
-![keybindings](http://i.imgur.com/1IXGhlS.gif)
-
 ![git](http://i.imgur.com/udkcPfB.gif)
+
+![keybindings](http://i.imgur.com/1IXGhlS.gif)
 
 Sublimious comes with a keybinding helper to ease you in with everything. Just hit `space` and a popup will tell you what you can perform.
 
@@ -39,6 +39,7 @@ In general, sublimious follows the spacemacs mnemonic:
 - `<spc> s` for the current (visual) selection
 - `<spc> e` for errors (linting)
 - `<spc> t` is for toggles (sidebar, statusbar)
+- `<spc> _` is for meta commands (sublimious reload)
 
 Sublimious tries to add vim-like keybindings for every plugin possible. Sidebar navigation for example has been remapped to `j/k`.
 
@@ -57,13 +58,13 @@ Sublimious tries to add vim-like keybindings for every plugin possible. Sidebar 
 - [x] submit to package control
 - [x] add install instructions to README
 - [x] add a better default .sublimious
+- [x] find a way to tell Package Control to reload (https://github.com/wbond/package_control/issues/997#issuecomment-141457037). This is needed to trigger pc after sublimious modified the pc settings file.
+- [x] add option to reload .sublimious (trigger all layer collections, writings, and package control reload)
 - [ ] add option to bind custom bindings to sublimious (e.g. user wants to bind action_123 to combination yyy). Should support both, sublimes system and sublimious system
 - [ ] add option to execute / register functions from within .sublimious (e.g. user adds `def xxx` and wants to bind that function to combination yyy)
 - [ ] allow multiple commands bound to the same key combination
 - [ ] fix initial installation process (currently throwing a ton of errors)
 - [ ] adjust the shortcut helper's width automagically
 - [ ] add better README files for each layer 
-- [ ] watch .sublimious file for changes and reload plugin (trigger all layer collections, writings, and package control reload)
-- [ ] find a way to tell Package Control to reload (https://github.com/wbond/package_control/issues/997#issuecomment-141457037). This is needed to trigger pc after sublimious modified the pc settings file.
 - [ ] ship Hack as default font and use it (possible?). If not, find a good preinstalled font and use that as default
 - [ ] find a way to bind content specific actions to a keybinding. (e.g. `<space> m` will always list actions based on the current syntax. In javascript this could list `format javascript code` and in python `autoflake8`)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ In general, sublimious follows the spacemacs mnemonic:
 
 Sublimious tries to add vim-like keybindings for every plugin possible. Sidebar navigation for example has been remapped to `j/k`.
 
+### Tips and Tricks
+
+- after changing your .sublimious file, hit `<spc> _ r` to re-feed your .sublimious config into sublimetext. All changes will be reloaded immediately. This includes packages, settings and layers.
+
 
 ### To-Dos:
 

--- a/commands.py
+++ b/commands.py
@@ -2,6 +2,14 @@ import sublime
 import sublime_plugin
 
 
+class ReloadSublimiousCommand(sublime_plugin.WindowCommand):
+    def run(self, *args, **kw):
+        print("Reloading sublimious....")
+
+        from . import sublimious
+        sublimious.plugin_loaded()
+
+
 class ShowSublimiousShortcutsCommand(sublime_plugin.TextCommand):
     def run(self, edit, arr):
         if len(arr) == 0:

--- a/layers/core/layer.py
+++ b/layers/core/layer.py
@@ -89,6 +89,10 @@ class Layer():
         {"keys": ["t", "t"], "command": "toggle_side_bar", "description": "toggle sidebar"},
         {"keys": ["t", "l"], "command": "toggle_setting", "args": {"setting": "line_numbers"}, "description": "toggle line numbers"},
         {"keys": ["t", "m"], "command": "toggle_minimap", "args": {}, "description": "toggle minimap"},
+
+        # ----- Meta
+        {"keys": ["_"], "category": "meta"},
+        {"keys": ["_", "r"], "command": "reload_sublimious", "description": "reload .sublimious"},
     ]
 
     sublime_keymap = [

--- a/lib/collector.py
+++ b/lib/collector.py
@@ -16,6 +16,12 @@ class Collector():
     zip_file = None
 
     def __init__(self, sublimious_dir, user_dir=None):
+        self.layers = []
+        self.collected_config = {}
+        self.user_config = {}
+        self.is_zip = False
+        self.zip_file = None
+
         if "sublime-package" in sublimious_dir:
             self.is_zip = True
             self.zip_file = zipfile.ZipFile(sublimious_dir)

--- a/lib/packagecontroller.py
+++ b/lib/packagecontroller.py
@@ -1,0 +1,27 @@
+import sys
+import os
+
+import sublime
+
+
+class PackageController:
+    user_dir = None
+
+    def __init__(self):
+        sublime_dir = os.path.dirname(sublime.packages_path())
+        installed_packages_dir = os.path.join(sublime_dir, 'Installed Packages')
+        packages_dir = os.path.join(sublime_dir, 'Packages')
+
+        self.user_dir = os.path.join(packages_dir, 'User')
+
+        package_control = os.path.join(installed_packages_dir, "Package Control.sublime-package")
+        sys.path.append(package_control)
+
+    def reload(self):
+        # We have to delete `Package Control.last-run` to not run into the cache
+        last_run_file = os.path.join(self.user_dir, "Package Control.last-run")
+        os.remove(last_run_file)
+
+        from package_control.package_cleanup import PackageCleanup
+        cleanup = PackageCleanup()
+        cleanup.start()

--- a/lib/packagecontroller.py
+++ b/lib/packagecontroller.py
@@ -20,8 +20,8 @@ class PackageController:
     def reload(self):
         # We have to delete `Package Control.last-run` to not run into the cache
         last_run_file = os.path.join(self.user_dir, "Package Control.last-run")
-        os.remove(last_run_file)
+        if os.path.isfile(last_run_file):
+            os.remove(last_run_file)
 
         from package_control.package_cleanup import PackageCleanup
-        cleanup = PackageCleanup()
-        cleanup.start()
+        sublime.set_timeout(lambda: PackageCleanup().start(), 2000)

--- a/sublimious.py
+++ b/sublimious.py
@@ -13,6 +13,7 @@ import json
 
 from .lib.collector import Collector
 from .lib.io import write_sublimious_file
+from .lib.packagecontroller import PackageController
 
 
 def plugin_loaded():
@@ -78,5 +79,9 @@ def plugin_loaded():
     # Take control over sublime settings file
     status_panel.run_command("status", {"text": "Taking control over Preferences.sublime-settings..."})
     write_sublimious_file(settings_file, json.dumps(collected_config))
+
+    status_panel.run_command("status", {"text": "Pinging package control"})
+    controller = PackageController()
+    controller.reload()
 
     status_panel.run_command("status", {"text": "ALL DONE!"})


### PR DESCRIPTION
Adds support for `<spc> _ r` to reload .sublimious. 

Sublimious now also automatically calls package control on startup so that packages and changes in layers will be reflected immediately 
