### PR TITLE
Support for using sublimious without a tabbar

### DIFF
--- a/layers/core/layer.py
+++ b/layers/core/layer.py
@@ -14,6 +14,7 @@ class Layer():
         "AdvancedNewFile",
         "InactivePanes",
         "Theme - Soda SolarizedDark",
+        "Tab Filter",
     ]
 
     sublimious_keymap = [
@@ -64,7 +65,7 @@ class Layer():
         {"keys": ["p", "c"], "command": "advanced_new_file_new", "description": "create file"},
 
         # ----- Buffers
-        {"keys": ["tab"], "command": "prev_view_in_stack", "description": "previous view"},
+        {"keys": ["tab"], "command": "next_view", "description": "previous buffer"},
 
         # ----- Errors
         {"keys": ["e"], "category": "errors"},
@@ -79,6 +80,7 @@ class Layer():
         # ----- Buffer
         {"keys": ["b"], "category": "buffer"},
         {"keys": ["b", "m"], "command": "advanced_new_file_move", "description": "move/rename file"},
+        {"keys": ["b", "b"], "command": "tab_filter", "description": "navigate buffers"},
 
         # ----- Toggles
         {"keys": ["t"], "category": "toggles"},

--- a/layers/core/layer.py
+++ b/layers/core/layer.py
@@ -3,20 +3,17 @@ class Layer():
 
     required_packages = [
         "sublimious",
+        "Package Control",
         "Vintage-Origami",
         "Vintageous",
+        "Vintageous​Plugin​Surround",
         "Origami",
-        "Package Control",
         "SublimeLinter",
         "Surround",
-        "Theme - Brogrammer",
-        "Theme - Nil",
-        "Theme - Soda",
-        "Theme - Spacegray",
         "BracketHighlighter",
         "AdvancedNewFile",
+        "InactivePanes",
         "Theme - Soda SolarizedDark",
-        "InactivePanes"
     ]
 
     sublimious_keymap = [
@@ -89,6 +86,7 @@ class Layer():
         {"keys": ["t", "t"], "command": "toggle_side_bar", "description": "toggle sidebar"},
         {"keys": ["t", "l"], "command": "toggle_setting", "args": {"setting": "line_numbers"}, "description": "toggle line numbers"},
         {"keys": ["t", "m"], "command": "toggle_minimap", "args": {}, "description": "toggle minimap"},
+        {"keys": ["t", "t"], "command": "toggle_tabs", "args": {}, "description": "toggle tabs"},
 
         # ----- Meta
         {"keys": ["_"], "category": "meta"},


### PR DESCRIPTION
Adds `b b` for navigating buffers and `tab` for switching back to last open files. The idea is to be able to get rid of the tabbar completely since it is often quite distracting. I like to focus on maximum 2-3 open files at once and jump around between them. 

This change makes tabs act like buffers in normal editors: They are open, you can navigate them and if you are done with them, you can close them. `b b` will be used to quickly jump to a previous file if it is not the last used one. 
