### PR TITLE
Add support for efficient usage without a tab bar

### DIFF
--- a/layers/core/layer.py
+++ b/layers/core/layer.py
@@ -81,6 +81,7 @@ class Layer():
         {"keys": ["b"], "category": "buffer"},
         {"keys": ["b", "m"], "command": "advanced_new_file_move", "description": "move/rename file"},
         {"keys": ["b", "b"], "command": "tab_filter", "description": "navigate buffers"},
+        {"keys": ["b", "c"], "command": "close", "description": "close buffer"},
 
         # ----- Toggles
         {"keys": ["t"], "category": "toggles"},

--- a/layers/core/layer.py
+++ b/layers/core/layer.py
@@ -6,7 +6,7 @@ class Layer():
         "Package Control",
         "Vintage-Origami",
         "Vintageous",
-        "Vintageous​Plugin​Surround",
+        "VintageousPluginSurround",
         "Origami",
         "SublimeLinter",
         "Surround",
@@ -14,7 +14,7 @@ class Layer():
         "AdvancedNewFile",
         "InactivePanes",
         "Theme - Soda SolarizedDark",
-        "Tab Filter",
+        "Extended​Tab​Switcher",
     ]
 
     sublimious_keymap = [
@@ -65,7 +65,7 @@ class Layer():
         {"keys": ["p", "c"], "command": "advanced_new_file_new", "description": "create file"},
 
         # ----- Buffers
-        {"keys": ["tab"], "command": "next_view", "description": "previous buffer"},
+        {"keys": ["<tab>"], "command": "next_view", "description": "previous buffer"},
 
         # ----- Errors
         {"keys": ["e"], "category": "errors"},
@@ -80,7 +80,7 @@ class Layer():
         # ----- Buffer
         {"keys": ["b"], "category": "buffer"},
         {"keys": ["b", "m"], "command": "advanced_new_file_move", "description": "move/rename file"},
-        {"keys": ["b", "b"], "command": "tab_filter", "description": "navigate buffers"},
+        {"keys": ["b", "b"], "command": "extended_switcher", "args": {"list_mode": "window"}, "description": "navigate buffers"},
         {"keys": ["b", "c"], "command": "close", "description": "close buffer"},
 
         # ----- Toggles

--- a/layers/core/layer.py
+++ b/layers/core/layer.py
@@ -14,6 +14,7 @@ class Layer():
         "AdvancedNewFile",
         "InactivePanes",
         "Theme - Soda SolarizedDark",
+        "Tab Filter",
     ]
 
     sublimious_keymap = [
@@ -64,7 +65,7 @@ class Layer():
         {"keys": ["p", "c"], "command": "advanced_new_file_new", "description": "create file"},
 
         # ----- Buffers
-        {"keys": ["tab"], "command": "prev_view_in_stack", "description": "previous view"},
+        {"keys": ["tab"], "command": "next_view", "description": "previous buffer"},
 
         # ----- Errors
         {"keys": ["e"], "category": "errors"},
@@ -79,6 +80,7 @@ class Layer():
         # ----- Buffer
         {"keys": ["b"], "category": "buffer"},
         {"keys": ["b", "m"], "command": "advanced_new_file_move", "description": "move/rename file"},
+        {"keys": ["b", "b"], "command": "tab_filter", "description": "navigate buffers"},
 
         # ----- Toggles
         {"keys": ["t"], "category": "toggles"},

--- a/layers/core/layer.py
+++ b/layers/core/layer.py
@@ -65,7 +65,7 @@ class Layer():
         {"keys": ["p", "c"], "command": "advanced_new_file_new", "description": "create file"},
 
         # ----- Buffers
-        {"keys": ["<tab>"], "command": "last_used_tab", "description": "previous buffer"},
+        {"keys": ["<tab>"], "command": "next_view_in_stack", "description": "previous buffer"},
 
         # ----- Errors
         {"keys": ["e"], "category": "errors"},

--- a/layers/core/layer.py
+++ b/layers/core/layer.py
@@ -14,7 +14,7 @@ class Layer():
         "AdvancedNewFile",
         "InactivePanes",
         "Theme - Soda SolarizedDark",
-        "Extended​Tab​Switcher",
+        "ExtendedTabSwitcher"
     ]
 
     sublimious_keymap = [
@@ -65,7 +65,7 @@ class Layer():
         {"keys": ["p", "c"], "command": "advanced_new_file_new", "description": "create file"},
 
         # ----- Buffers
-        {"keys": ["<tab>"], "command": "next_view", "description": "previous buffer"},
+        {"keys": ["<tab>"], "command": "last_used_tab", "description": "previous buffer"},
 
         # ----- Errors
         {"keys": ["e"], "category": "errors"},


### PR DESCRIPTION
Adds `b b` for navigating buffers and `tab` for switching back to last open tab. The idea is to be able to get rid of the tabbar completely since it is often quite distracting. I like to focus on maximum 2-3 open files at once and jump around between them. 

This change makes tabs act like normal buffers in other editors: They are open, you can navigate them and if you are done with them, you can close them. `b b` will be used to quickly jump to a previous file and `tab` to the last used tab. 
