### PR TITLE
Use Package Control directly for package installation

### DIFF
--- a/lib/package_controller.py
+++ b/lib/package_controller.py
@@ -1,6 +1,8 @@
 import sys
 import os
 
+from .package_resolver import PackageResolver
+
 import sublime
 
 
@@ -20,22 +22,22 @@ class PackageController:
         from package_control.package_manager import PackageManager
         self.package_control = PackageManager()
 
-    def install_package(self, package_name):
-        self.package_control.install_package(package_name)
-
     def install_packages(self, packages, wipe_others=True):
         if wipe_others:
             installed_packages = self.package_control.list_packages()
 
+            to_remove = []
             for pkg in installed_packages:
                 if pkg not in packages:
-                    self.package_control.remove_package(pkg)
+                    to_remove.append(pkg)
 
+        to_install = []
         for pkg in packages:
             if pkg in installed_packages:
                 continue
+            to_install.append(pkg)
 
-            self.install_package(pkg)
+        PackageResolver(self.package_control, to_install, to_remove).start()
 
     def reload(self):
         # We have to delete `Package Control.last-run` to not run into the cache

--- a/lib/package_resolver.py
+++ b/lib/package_resolver.py
@@ -1,0 +1,16 @@
+import threading
+
+
+class PackageResolver(threading.Thread):
+    def __init__(self, package_control, packages, to_remove):
+        self.package_control = package_control
+        self.packages = packages
+        self.to_remove = to_remove
+        threading.Thread.__init__(self)
+
+    def run(self):
+        for pkg in self.to_remove:
+            self.package_control.remove_package(pkg)
+
+        for pkg in self.packages:
+            self.package_control.install_package(pkg)

--- a/lib/packagecontroller.py
+++ b/lib/packagecontroller.py
@@ -17,6 +17,26 @@ class PackageController:
         package_control = os.path.join(installed_packages_dir, "Package Control.sublime-package")
         sys.path.append(package_control)
 
+        from package_control.package_manager import PackageManager
+        self.package_control = PackageManager()
+
+    def install_package(self, package_name):
+        self.package_control.install_package(package_name)
+
+    def install_packages(self, packages, wipe_others=True):
+        if wipe_others:
+            installed_packages = self.package_control.list_packages()
+
+            for pkg in installed_packages:
+                if pkg not in packages:
+                    self.package_control.remove_package(pkg)
+
+        for pkg in packages:
+            if pkg in installed_packages:
+                continue
+
+            self.install_package(pkg)
+
     def reload(self):
         # We have to delete `Package Control.last-run` to not run into the cache
         last_run_file = os.path.join(self.user_dir, "Package Control.last-run")

--- a/sublimious.py
+++ b/sublimious.py
@@ -13,7 +13,7 @@ import json
 
 from .lib.collector import Collector
 from .lib.io import write_sublimious_file
-from .lib.packagecontroller import PackageController
+from .lib.package_controller import PackageController
 
 
 def plugin_loaded():
@@ -50,7 +50,11 @@ def plugin_loaded():
     settings_current = [os.path.join(sublimious_packages_dir, f) for f in os.listdir(sublimious_packages_dir) if f.endswith(".sublime-settings")]
     filelist = settings_current + settings_user
 
+    # Delete all settings except Package Control
     for f in filelist:
+        if "Package Control" in f:
+            continue
+
         os.remove(f)
 
     # Second iteration to initialise all layers with config

--- a/sublimious.py
+++ b/sublimious.py
@@ -24,6 +24,8 @@ def plugin_loaded():
     sublimious_packages_dir = os.path.join(packages_dir, 'sublimious/')
     user_dir = os.path.join(packages_dir, 'User')
 
+    package_controller = PackageController()
+
     status_panel = sublime.active_window().create_output_panel("sublimious_status_panel")
     sublime.active_window().run_command("show_panel", {"panel": "output.sublimious_status_panel", "toggle": False})
 
@@ -60,7 +62,7 @@ def plugin_loaded():
     # Collect all packages
     status_panel.run_command("status", {"text": "Collecting all packages..."})
     all_packages = collector.collect_key("required_packages") + collector.get_user_config().additional_packages
-    write_sublimious_file(pcontrol_settings, json.dumps({'installed_packages': all_packages}))
+    package_controller.install_packages(all_packages)
 
     # Get all keybinding definitions and save to keymapfile
     status_panel.run_command("status", {"text": "Building keymap..."})
@@ -79,9 +81,5 @@ def plugin_loaded():
     # Take control over sublime settings file
     status_panel.run_command("status", {"text": "Taking control over Preferences.sublime-settings..."})
     write_sublimious_file(settings_file, json.dumps(collected_config))
-
-    status_panel.run_command("status", {"text": "Pinging package control"})
-    controller = PackageController()
-    controller.reload()
 
     status_panel.run_command("status", {"text": "ALL DONE!"})


### PR DESCRIPTION
Right now, we are dumping all packages into `Package Control.sublime-settings`. What happens because of that is, that packages that are installed but not in that list will start ignoring themselves and the user gets a ton of popups (https://github.com/dvcrn/sublimious/issues/10).

This is a horrible first-start experience and scared many users away that think that sublimious is just flat out broken

With this PR, sublimious will use normal Package Control for first removing packages that are not needed anymore, and then installing stuff that is needed. 
