### PR TITLE
fix(corelayer): changed <spc> / description to 'smart search'

### DIFF
--- a/layers/core/layer.py
+++ b/layers/core/layer.py
@@ -69,7 +69,7 @@ class Layer():
         {"keys": ["p", "c"], "command": "advanced_new_file_new", "description": "create file"},
         {"keys": ["p", "R"], "command": "reveal_in_side_bar", "description": "reveal file"},
         {"keys": ["p", "s"], "command": "show_panel", "args": {"panel": "find_in_files"}, "description": "search file"},
-        {"keys": ["/"], "command": "show_panel", "args": {"panel": "find_in_files"}, "description": "create file"},
+        {"keys": ["/"], "command": "show_panel", "args": {"panel": "find_in_files"}, "description": "smart search"},
         {"keys": ["p", "p"], "command": "prompt_select_workspace", "args": {}, "description": "switch project"},
 
         # ----- Buffers


### PR DESCRIPTION
Arguably a style change, the description for <spc> / has changed from 'create file' to 'smart search'. The command actually runs find in files, and I chose the name for consistency with Spacemacs.

Closes #32
