### PR TITLE
feat(core): add external repos for package installs

### DIFF
--- a/sublimious.py
+++ b/sublimious.py
@@ -54,6 +54,22 @@ class Sublimious():
         for layer in self.collector.get_layers():
             layer.init(collected_config)
 
+        # Add repositories
+        repositories = self.collector.get_user_config().repositories
+
+        pctl_settings_file = os.path.join(
+            self.user_dir,
+            "Package Control.sublime-settings"
+        )
+        with open(pctl_settings_file, "r") as pctl_settings:
+            data = json.load(pctl_settings)
+            if repositories:
+                data["repositories"] = repositories
+            else:
+                data["repositories"] = []
+            with open(pctl_settings_file, "w") as pctl_settings:
+                json.dump(data, pctl_settings)
+
         # Collect all packages
         all_packages = self.collector.collect_key("required_packages") + self.collector.get_user_config().additional_packages
         package_controller.install_packages(all_packages, callback=self.after_install)

--- a/sublimious.py
+++ b/sublimious.py
@@ -54,6 +54,22 @@ class Sublimious():
         for layer in self.collector.get_layers():
             layer.init(collected_config)
 
+        # Add repositories
+        repositories = self.collector.get_user_config().repositories
+
+        if repositories:
+            pctl_settings_file = os.path.join(
+                self.user_dir,
+                "Package Control.sublime-settings"
+            )
+            self.status_panel.run_command("status", {"text": repositories})
+            with open(pctl_settings_file, "r") as pc_settings:
+                data = json.load(pc_settings)
+                self.status_panel.run_command("status", {"text": "test"})
+                data["repositories"] = repositories
+                with open(pctl_settings_file, "w") as pc_settings:
+                    json.dump(data, pc_settings)
+
         # Collect all packages
         all_packages = self.collector.collect_key("required_packages") + self.collector.get_user_config().additional_packages
         package_controller.install_packages(all_packages, callback=self.after_install)

--- a/templates/.sublimious
+++ b/templates/.sublimious
@@ -25,6 +25,14 @@ layers = [
     # 'clojure'
 ]
 
+
+"""
+Add repository URLs here if these are needed to install some of your packages.
+"""
+repositories = [
+
+]
+
 """
 Everything that is not part of a layer.
 These packages will be installed through package control


### PR DESCRIPTION
I'll admit, I had totally forgotten about having asked you questions in how I could implement this.

This works but has a slight bug, I wonder if you have some insight:

- If both repo and package are added at the same time it works fine
- If the repo is added, settings are reloaded, and then the package is added, it works fine
- If the package is added, settings are reloaded, Package Control will complain that it can't find the package (which is the expected behaviour). However, if I now add the repo to the list, when I reload Package Control will complain again about the package not being found. Only on the second reload will the package install correctly.

Any reason for this? Should I add the repos way earlier in the process? 

Closes #39